### PR TITLE
V17 update for bagisto appliance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 COMMON_CONF = nodejs
 PHP_VERSION=8.1
+PHP_EXTRA_PINS=libpcre2-8-0
 
 include $(FAB_PATH)/common/mk/turnkey/lamp.mk
 include $(FAB_PATH)/common/mk/turnkey/laravel.mk

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 COMMON_CONF = nodejs
+PHP_VERSION=8.1
 
 include $(FAB_PATH)/common/mk/turnkey/lamp.mk
 include $(FAB_PATH)/common/mk/turnkey/laravel.mk

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 COMMON_CONF = nodejs
+PHP_EXTRA_PINS=libpcre2-8-0 libgd3
 PHP_VERSION=8.1
-PHP_EXTRA_PINS=libpcre2-8-0
 
 include $(FAB_PATH)/common/mk/turnkey/lamp.mk
 include $(FAB_PATH)/common/mk/turnkey/laravel.mk

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,7 @@ Credentials *(passwords set at first boot)*
 -  Adminer: username **adminer**
 
 -  Bagisto: username is email - set at firstboot
+   Login at http://<Bagisto_IP>/admin/login
 
 .. _Bagisto: https://bagisto.com/en/
 .. _extensions: https://bagisto.com/en/extensions/

--- a/changelog
+++ b/changelog
@@ -5,6 +5,10 @@ turnkey-bagisto-17.0 (1) turnkey; urgency=low
   * Forcing appliance to use sury.org repo instead of Debian.
 
   * Installing php packages with version 8.1, included "extra pins" in Makefile.
+  
+  * Implementing services.txt file to update admin login page for appliance.
+  
+  * Including login page url in ReadMe.rst file.
 
   * Update Bagisto to latest upstream stable - v1.3.2.
     [Zhenya Hvorostian <zhenya@turnkeylinux.org>]

--- a/changelog
+++ b/changelog
@@ -1,12 +1,18 @@
 turnkey-bagisto-17.0 (1) turnkey; urgency=low
 
+  * Updating Bagisto appliance and its dependencies to v17.0. 
+
+  * Forcing appliance to use sury.org repo instead of Debian.
+
+  * Installing php packages with version 8.1.
+
   * Update Bagisto to latest upstream stable - v1.3.2.
+    [Zhenya Hvorostian <zhenya@turnkeylinux.org>]
 
   * Note: Please refer to turnkey-core's 17.0 changelog for changes common to
     all appliances. Here we only describe changes specific to this appliance.
-
- -- Zhenya Hvorostian <zhenya@turnkeylinux.org>  Wed, 09 Feb 2022 22:55:55 +0300
-
+ 
+-- Mattie Darden <mattie@turnkeylinux.org>  Thu, 22 Sep 2022 18:41:52 -0400
 
 turnkey-bagisto-16.1 (1) turnkey; urgency=low
 

--- a/changelog
+++ b/changelog
@@ -4,7 +4,7 @@ turnkey-bagisto-17.0 (1) turnkey; urgency=low
 
   * Forcing appliance to use sury.org repo instead of Debian.
 
-  * Installing php packages with version 8.1.
+  * Installing php packages with version 8.1, included "extra pins" in Makefile.
 
   * Update Bagisto to latest upstream stable - v1.3.2.
     [Zhenya Hvorostian <zhenya@turnkeylinux.org>]

--- a/overlay/etc/confconsole/services.txt
+++ b/overlay/etc/confconsole/services.txt
@@ -1,0 +1,7 @@
+Web:        http://$ipaddr
+            https://$ipaddr
+            https://$ipaddr/admin/login
+Web shell:  https://$ipaddr:12320
+Webmin:     https://$ipaddr:12321
+Adminer:    https://$ipaddr:12322
+SSH/SFTP:   root@$ipaddr (port 22)

--- a/overlay/usr/lib/inithooks/bin/bagisto.py
+++ b/overlay/usr/lib/inithooks/bin/bagisto.py
@@ -9,8 +9,8 @@ Option:
 import sys
 import getopt
 import bcrypt
-from mysqlconf import MySQL
 
+from mysqlconf import MySQL
 from libinithooks.dialog_wrapper import Dialog
 from libinithooks import inithooks_cache
 

--- a/plan/main
+++ b/plan/main
@@ -1,14 +1,14 @@
 #include <turnkey/base>
-#include <turnkey/lamp>
+#include <turnkey/lamp81>
 
 python3-bcrypt
 
 build-essential
 
-php-curl
 php-json
-php-mbstring
-php-gd
-php-zip
-php-xml
-php-intl
+php8.1-curl
+php8.1-mbstring
+php8.1-gd
+php8.1-zip
+php8.1-xml
+php8.1-intl


### PR DESCRIPTION
PR updates bagisto and dependencies to v17.0. Version changes force application install to use sury.org repo and install version 8.1 needed for appliance, instead of 7.4 Debian default. Additional "php extra pins" are included in Makefile. All update changes have been documented in changelog per tkldev standards. Readme.rst has also been reviewed to ensure all links are valid, and that the steps/ information provided is still relevant. Added services.txt file to show correct admin login for bagisto appliance. Included this change documentation to readme.rst file as well.